### PR TITLE
Negative destination and fixed FFmpeg tests

### DIFF
--- a/ad-insertion/video-analytics-service/app/modules/PipelineManager.py
+++ b/ad-insertion/video-analytics-service/app/modules/PipelineManager.py
@@ -45,15 +45,15 @@ class PipelineManager:
 
             else:
                 if len(files) == 0:
-                    pipeline = root.split('/')[-1]
+                    pipeline = os.path.basename(root)
                     pipelines[pipeline] = {}
                     for subdir in subdirs:
                         pipelines[pipeline][subdir] = {}
                 else:
-                    pipeline = root.split('/')[-2]
-                    version = root.split('/')[-1]
+                    pipeline = os.path.basename(os.path.dirname(root))
+                    version = os.path.basename(root)
                     for file in files:
-                        path = root + '/' + file
+                        path = os.path.join(root, file)
                         if path.endswith(".json"):
                             with open(path, 'r') as jsonfile:
                                 config = json.load(jsonfile)

--- a/ad-insertion/video-analytics-service/app/modules/test/test_Destination.py
+++ b/ad-insertion/video-analytics-service/app/modules/test/test_Destination.py
@@ -1,14 +1,17 @@
 import sys, os
-sys.path.append(os.path.dirname(__file__) + "/../../")
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 import unittest
 import common
+from common.utils import logging  # pylint: disable=import-error
 
 import modules.Destination as Destination
+from contextlib import contextmanager
+from io import StringIO
 
 class TestDestination(unittest.TestCase):
 
-    def test_create_instance(self):
+    def test_create_instance_kafka(self):
         request = {
             "destination": {
                 "type": "kafka"
@@ -22,6 +25,34 @@ class TestDestination(unittest.TestCase):
         result = Destination.create_instance(request)
 
         self.assertIsInstance(result, MockKafkaDestination)
+
+    def test_create_instance_bad_type(self):
+        request = {
+            "destination": {
+                "type": "test"
+            }
+        }
+        MockKafkaDestination = type("MockKafkaDestination", (object,), {
+            "__init__": lambda self, destination: None
+        })
+        Destination.destination_types['kafka'] = MockKafkaDestination
+        logger = logging.get_logger('DestinationTypes', is_static=True)
+
+        with self.assertLogs(logger=logger,level='DEBUG') as cm:
+            result = Destination.create_instance(request)
+        self.assertIn("Error", cm.output.pop())
+
+    def test_create_instance_empty_request(self):
+        request = None
+        MockKafkaDestination = type("MockKafkaDestination", (object,), {
+            "__init__": lambda self, destination: None
+        })
+        Destination.destination_types['kafka'] = MockKafkaDestination
+        logger = logging.get_logger('DestinationTypes', is_static=True)
+
+        with self.assertLogs(logger=logger,level='DEBUG') as cm:
+            result = Destination.create_instance(request)
+        self.assertIn("Error", cm.output.pop())
 
 if __name__ == '__main__':
     unittest.main()

--- a/ad-insertion/video-analytics-service/app/modules/test/test_FileDestination.py
+++ b/ad-insertion/video-analytics-service/app/modules/test/test_FileDestination.py
@@ -1,5 +1,5 @@
 import sys, os
-sys.path.append(os.path.dirname(__file__) + "/../../")
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 import unittest
 from unittest.mock import patch

--- a/ad-insertion/video-analytics-service/app/modules/test/test_GStreamerPipeline.py
+++ b/ad-insertion/video-analytics-service/app/modules/test/test_GStreamerPipeline.py
@@ -1,5 +1,5 @@
 import sys, os
-sys.path.append(os.path.dirname(__file__) + "/../../")
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 import unittest
 from unittest.mock import patch

--- a/ad-insertion/video-analytics-service/app/modules/test/test_ModelManager.py
+++ b/ad-insertion/video-analytics-service/app/modules/test/test_ModelManager.py
@@ -1,5 +1,5 @@
 import sys, os
-sys.path.append(os.path.dirname(__file__) + "/../../")
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 import unittest
 import common

--- a/ad-insertion/video-analytics-service/app/modules/test/test_PipelineManager.py
+++ b/ad-insertion/video-analytics-service/app/modules/test/test_PipelineManager.py
@@ -1,5 +1,5 @@
 import sys, os
-sys.path.append(os.path.dirname(__file__) + "/../../")
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 import unittest
 import common
@@ -149,7 +149,8 @@ class TestPipelineManager(unittest.TestCase):
                 }
             }
         }
-        PipelineManager.load_config("modules/test/pipelines")
+
+        PipelineManager.load_config(os.path.join("modules", "test", "pipelines"))
         result = PipelineManager.pipelines
 
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
Fix tests and PipelineManager.py so they use cross-platform os.path methods